### PR TITLE
feat(agent): Update Claude Code settings

### DIFF
--- a/agent/claude/settings.json
+++ b/agent/claude/settings.json
@@ -65,7 +65,7 @@
   "theme": "dark-ansi",
   "editorMode": "vim",
   "terminalProgressBarEnabled": false,
+  "agentPushNotifEnabled": true,
   "skipAutoPermissionPrompt": true,
-  "enableTips": false,
-  "agentPushNotifEnabled": true
+  "enableTips": false
 }

--- a/agent/claude/settings.json
+++ b/agent/claude/settings.json
@@ -33,6 +33,7 @@
     ],
     "defaultMode": "auto"
   },
+  "model": "opus[1m]",
   "enabledMcpjsonServers": [
     "apple-notes"
   ],
@@ -59,11 +60,12 @@
     "cloudflare@claude-plugins-official": true
   },
   "effortLevel": "xhigh",
+  "tui": "fullscreen",
   "skipDangerousModePermissionPrompt": true,
   "theme": "dark-ansi",
-  "terminalProgressBarEnabled": false,
   "editorMode": "vim",
+  "terminalProgressBarEnabled": false,
   "skipAutoPermissionPrompt": true,
   "enableTips": false,
-  "model": "claude-fable-5[1m]"
+  "agentPushNotifEnabled": true
 }


### PR DESCRIPTION
## Summary

Tune the Claude Code environment to match current preferences — model, terminal renderer, and notifications.

## Changes

- Switch the pinned model from `claude-fable-5[1m]` to `opus[1m]`
- Enable the fullscreen TUI renderer (`tui: fullscreen`)
- Turn on agent push notifications (`agentPushNotifEnabled`)