### PR TITLE
fix(tmux): Keep the rename prompt from drifting across the status line

### DIFF
--- a/tmux/.tmux.conf
+++ b/tmux/.tmux.conf
@@ -53,6 +53,11 @@ set -g status-left-length 100
 set -g status-left ""
 set -g status-right "#{E:@catppuccin_status_application} #{E:@catppuccin_status_session}"
 
+# catppuccin sets message-style align=centre, which tmux >= 3.7 uses to float
+# the command/rename prompt mid-status-line; pin it left over a cleared line
+set -g message-style "fg=#94e2d5,bg=#313244,align=left,width=100%,fill=#313244"
+set -g message-command-style "fg=#94e2d5,bg=#313244,align=left,width=100%,fill=#313244"
+
 # Dim inactive panes
 set -g window-style "bg=#181825"
 set -g window-active-style "bg=#1e1e2e"


### PR DESCRIPTION
## Summary

On tmux 3.7 the command/rename prompt floats over the status bar at a position controlled by `message-style`'s `align`/`width` attributes. catppuccin sets `align=centre` with no width, so the `prefix + ,` rename prompt appeared mid-status-line and drifted with its content length, with window tabs showing through behind it.

## Changes

- Override `message-style` and `message-command-style` after tpm loads: `align=left,width=100%,fill=#313244`, keeping catppuccin's teal-on-surface prompt colors.